### PR TITLE
pack None float values as NaN

### DIFF
--- a/code.py
+++ b/code.py
@@ -5,6 +5,7 @@ Acquire values from various sensors, publish to MQTT topic or send via RFM69, en
 
 This is meant for battery powered devices such as QtPy or ESP32 based devices from Adafruit.
 """
+
 import time
 import traceback
 

--- a/data.py
+++ b/data.py
@@ -20,7 +20,7 @@ DATA_PACK_FMT = f">{len(MQTT_PREFIX)}s{MAX_MQTT_TOPIC_LEN}sffIff"
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def pack_data(
-    mqtt_topic: str, battery_level, co2_ppm, humidity, temperature, lux
+    mqtt_topic: str, battery_capacity, co2_ppm, humidity, temperature, lux
 ) -> bytes:
     """
     Pack the structure with data.
@@ -31,9 +31,24 @@ def pack_data(
         # Assuming ASCII encoding.
         raise ValueError(f"Maximum MQTT topic length is {MAX_MQTT_TOPIC_LEN}")
 
-    logger.info(
-        f"Sending data over radio: {(humidity, temperature, co2_ppm, battery_level, lux)}"
-    )
+    if temperature is None:
+        temperature = float("nan")
+
+    if humidity is None:
+        humidity = float("nan")
+
+    if battery_capacity is None:
+        battery_level = float("nan")
+    else:
+        battery_level = battery_capacity
+
+    if co2_ppm is None:
+        co2_ppm = -1
+
+    if lux is None:
+        lux = float("nan")
+
+    logger.info(f"Packing data: {(humidity, temperature, co2_ppm, battery_level, lux)}")
     data = struct.pack(
         DATA_PACK_FMT,
         MQTT_PREFIX.encode("ascii"),
@@ -85,23 +100,6 @@ def send_data(
             logger.warning("No sensor data available, will not send anything")
             return
 
-        if temperature is None:
-            temperature = float("nan")
-
-        if humidity is None:
-            humidity = float("nan")
-
-        if battery_capacity is None:
-            battery_level = float("nan")
-        else:
-            battery_level = battery_capacity
-
-        if co2_ppm is None:
-            co2_ppm = -1
-
-        if lux is None:
-            lux = float("nan")
-
         #
         # mypy gets confused by the 'data' variable assignment in the adjacent
         # if branch above and thinks it should be of type dict and complains:
@@ -113,7 +111,7 @@ def send_data(
         # to make it happy).
         #
         data = pack_data(
-            mqtt_topic, battery_level, co2_ppm, humidity, temperature, lux
+            mqtt_topic, battery_capacity, co2_ppm, humidity, temperature, lux
         )  # type: ignore [assignment]
         logger.debug(f"Raw data to be sent: {data}")
         rfm69.send(data)

--- a/data.py
+++ b/data.py
@@ -9,6 +9,14 @@ import adafruit_logging as logging
 
 from sensors import Sensors
 
+#
+# Note: at most 60 bytes can be sent in single packet so pack the data.
+# The following encoding scheme was designed to fit that constraint.
+#
+MAX_MQTT_TOPIC_LEN = 32
+MQTT_PREFIX = "MQTT:"
+DATA_PACK_FMT = f">{len(MQTT_PREFIX)}s{MAX_MQTT_TOPIC_LEN}sffIff"
+
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def pack_data(
@@ -19,20 +27,16 @@ def pack_data(
     """
     logger = logging.getLogger("")
 
-    # Note: at most 60 bytes can be sent in single packet so pack the data.
-    # The following encoding scheme was designed to fit that constraint.
-    mqtt_prefix = "MQTT:"
-    max_mqtt_topic_len = 32
-    if len(mqtt_topic) > max_mqtt_topic_len:
+    if len(mqtt_topic) > MAX_MQTT_TOPIC_LEN:
         # Assuming ASCII encoding.
-        raise ValueError(f"Maximum MQTT topic length is {max_mqtt_topic_len}")
-    fmt = f">{len(mqtt_prefix)}s{max_mqtt_topic_len}sffIff"
+        raise ValueError(f"Maximum MQTT topic length is {MAX_MQTT_TOPIC_LEN}")
+
     logger.info(
         f"Sending data over radio: {(humidity, temperature, co2_ppm, battery_level, lux)}"
     )
     data = struct.pack(
-        fmt,
-        mqtt_prefix.encode("ascii"),
+        DATA_PACK_FMT,
+        MQTT_PREFIX.encode("ascii"),
         mqtt_topic.encode("ascii"),
         humidity,
         temperature,
@@ -41,6 +45,13 @@ def pack_data(
         lux,
     )
     return data
+
+
+def unpack_data(data):
+    """
+    Unpack data into tuple. Used only for testing.
+    """
+    return struct.unpack(DATA_PACK_FMT, data)
 
 
 def send_data(
@@ -75,21 +86,21 @@ def send_data(
             return
 
         if temperature is None:
-            temperature = 0
+            temperature = float("nan")
 
         if humidity is None:
-            humidity = 0
+            humidity = float("nan")
 
         if battery_capacity is None:
-            battery_level = 0
+            battery_level = float("nan")
         else:
             battery_level = battery_capacity
 
         if co2_ppm is None:
-            co2_ppm = 0
+            co2_ppm = -1
 
         if lux is None:
-            lux = 0
+            lux = float("nan")
 
         #
         # mypy gets confused by the 'data' variable assignment in the adjacent

--- a/data.py
+++ b/data.py
@@ -31,19 +31,19 @@ def pack_data(
         # Assuming ASCII encoding.
         raise ValueError(f"Maximum MQTT topic length is {MAX_MQTT_TOPIC_LEN}")
 
+    if humidity is None:
+        humidity = float("nan")
+
     if temperature is None:
         temperature = float("nan")
 
-    if humidity is None:
-        humidity = float("nan")
+    if co2_ppm is None:
+        co2_ppm = 0
 
     if battery_capacity is None:
         battery_level = float("nan")
     else:
         battery_level = battery_capacity
-
-    if co2_ppm is None:
-        co2_ppm = 0
 
     if lux is None:
         lux = float("nan")

--- a/data.py
+++ b/data.py
@@ -43,7 +43,7 @@ def pack_data(
         battery_level = battery_capacity
 
     if co2_ppm is None:
-        co2_ppm = -1
+        co2_ppm = 0
 
     if lux is None:
         lux = float("nan")

--- a/test_struct.py
+++ b/test_struct.py
@@ -2,9 +2,11 @@
 test structure packing
 """
 
+import math
+
 import pytest
 
-from data import pack_data
+from data import pack_data, unpack_data
 
 
 def test_pack():
@@ -13,6 +15,22 @@ def test_pack():
     """
     data = pack_data("foo/bar", 80, 1200, 33, 21, 4000)
     assert len(data) <= 60
+
+
+def test_pack_none():
+    """
+    call the pack_data() to ensure it packs the None values as float('nan')
+    or -1 in case of float and integer, respectively.
+    """
+    topic = "foo/bar"
+    data = pack_data(topic, None, None, None, None, None)
+    topic_unpacked, battery_level, co2_ppm, humidity, temperature, lux = unpack(data)
+    assert topic_unpacked == topic
+    assert math.isnan(battery_level)
+    assert co2_ppm == -1
+    assert math.isnan(humidity)
+    assert math.isnan(temperature)
+    assert math.isnan(lux)
 
 
 def test_mqtt_topic_length_max():

--- a/test_struct.py
+++ b/test_struct.py
@@ -24,7 +24,9 @@ def test_pack_none():
     """
     topic = "foo/bar"
     data = pack_data(topic, None, None, None, None, None)
-    topic_unpacked, battery_level, co2_ppm, humidity, temperature, lux = unpack(data)
+    topic_unpacked, battery_level, co2_ppm, humidity, temperature, lux = unpack_data(
+        data
+    )
     assert topic_unpacked == topic
     assert math.isnan(battery_level)
     assert co2_ppm == -1

--- a/test_struct.py
+++ b/test_struct.py
@@ -24,7 +24,7 @@ def test_pack_none():
     """
     expected_topic = "foo/bar"
     data = pack_data(expected_topic, None, None, None, None, None)
-    mqtt_prefix, topic_unpacked, battery_level, co2_ppm, humidity, temperature, lux = (
+    mqtt_prefix, topic_unpacked, humidity, temperature, co2_ppm, battery_level, lux = (
         unpack_data(data)
     )
     assert mqtt_prefix.decode("ascii") == "MQTT:"

--- a/test_struct.py
+++ b/test_struct.py
@@ -27,8 +27,8 @@ def test_pack_none():
     mqtt_prefix, topic_unpacked, battery_level, co2_ppm, humidity, temperature, lux = (
         unpack_data(data)
     )
-    assert mqtt_prefix == "MQTT:"
-    assert topic_unpacked == topic
+    assert mqtt_prefix.decode("ascii") == "MQTT:"
+    assert topic_unpacked.decode("ascii") == topic
     assert math.isnan(battery_level)
     assert co2_ppm == 0
     assert math.isnan(humidity)

--- a/test_struct.py
+++ b/test_struct.py
@@ -24,12 +24,13 @@ def test_pack_none():
     """
     topic = "foo/bar"
     data = pack_data(topic, None, None, None, None, None)
-    topic_unpacked, battery_level, co2_ppm, humidity, temperature, lux = unpack_data(
-        data
+    mqtt_prefix, topic_unpacked, battery_level, co2_ppm, humidity, temperature, lux = (
+        unpack_data(data)
     )
+    assert mqtt_prefix == "MQTT:"
     assert topic_unpacked == topic
     assert math.isnan(battery_level)
-    assert co2_ppm == -1
+    assert co2_ppm == 0
     assert math.isnan(humidity)
     assert math.isnan(temperature)
     assert math.isnan(lux)

--- a/test_struct.py
+++ b/test_struct.py
@@ -22,13 +22,17 @@ def test_pack_none():
     call the pack_data() to ensure it packs the None values as float('nan')
     or -1 in case of float and integer, respectively.
     """
-    topic = "foo/bar"
-    data = pack_data(topic, None, None, None, None, None)
+    expected_topic = "foo/bar"
+    data = pack_data(expected_topic, None, None, None, None, None)
     mqtt_prefix, topic_unpacked, battery_level, co2_ppm, humidity, temperature, lux = (
         unpack_data(data)
     )
     assert mqtt_prefix.decode("ascii") == "MQTT:"
-    assert topic_unpacked.decode("ascii") == topic
+    mqtt_topic = topic_unpacked.decode("ascii")
+    nul_idx = mqtt_topic.find("\x00")
+    if nul_idx > 0:
+        mqtt_topic = mqtt_topic[:nul_idx]
+    assert mqtt_topic == expected_topic
     assert math.isnan(battery_level)
     assert co2_ppm == 0
     assert math.isnan(humidity)


### PR DESCRIPTION
This changes the way None values are packed as float values into NaN, making it easy for the receiver to recognize invalid values.

The integer value for CO2 was left intact as it is currently packed as `I`, i.e. unsigned integer and changing it into signed integer would necessitate to update all the transmitters which I do not want to do right now. The CO2 values are always non zero anyway.